### PR TITLE
Bugfix: Fix zombie chrome process issue

### DIFF
--- a/src/BL/Scrapers/TikTokScraper.ts
+++ b/src/BL/Scrapers/TikTokScraper.ts
@@ -122,7 +122,7 @@ export class TTScraper {
     const tiktokPage = await page.goto(url, { waitUntil: "domcontentloaded" });
 
     if (tiktokPage == null) {
-      await browser.close()
+      await browser.close();
       throw new Error("Could not load the desired Page!");
     }
 

--- a/src/BL/Scrapers/TikTokScraper.ts
+++ b/src/BL/Scrapers/TikTokScraper.ts
@@ -122,6 +122,7 @@ export class TTScraper {
     const tiktokPage = await page.goto(url, { waitUntil: "domcontentloaded" });
 
     if (tiktokPage == null) {
+      await browser.close()
       throw new Error("Could not load the desired Page!");
     }
 


### PR DESCRIPTION
In the case that we look up a tiktok page that ends up being null, we would fail to call `browser.close()`. This has the potential to cause an enormous amount of headless chrome zombie processes if this issue is hit at scale. 